### PR TITLE
Capacitor bootstrap charging ISR step function

### DIFF
--- a/motor_controller/motorbench-test-project/motorbench-test-project/rb_library/rb_pwm.c
+++ b/motor_controller/motorbench-test-project/motorbench-test-project/rb_library/rb_pwm.c
@@ -1,6 +1,109 @@
 #include "rb_pwm.h"
+#include "pwm_hs/pwm.h"
 
-void RB_PWMInit(void)
+#include "parameters/hal_params.h"
+#include "hal/hardware_access_functions.h"
+
+void RB_PWMInit(void) 
 {
-    
+
 }
+
+bool RB_PWMCapBootstrapISRStep(RB_BOOTSTRAP *pBootstrap) {
+
+    bool bootstrapDone = false;
+
+    switch (pBootstrap->state) {
+        case RBBS_IDLE:
+            // Disable PWMs
+            HAL_PWM_Outputs_Disable();
+            // Specify duties
+            pBootstrap->dutyA = HAL_PARAM_PWM_PERIOD_COUNTS;
+            pBootstrap->dutyB = HAL_PARAM_PWM_PERIOD_COUNTS;
+            pBootstrap->dutyC = HAL_PARAM_PWM_PERIOD_COUNTS;
+            // Overrides, don't fully understand
+            // First example project seems to do this differently 
+            HAL_PWM_UpperTransistorsOverride_Low();
+            HAL_PWM_LowerTransistorsOverride_Disable();
+            // State transition
+            pBootstrap->state = RBBS_INIT_WAIT;
+            pBootstrap->delayCount = MCAF_BOARD_BOOTSTRAP_INITIAL_DELAY;
+            break;
+            
+        case RBBS_INIT_WAIT:
+            // Wait some time before charging 
+            if (pBootstrap->delayCount == 0)
+            {   
+                pBootstrap->state = MCBS_PHASE_A_SETUP_CHARGING;
+            }
+            break;
+            
+        case RBBS_A_SETUP:
+            // Set PWM A duty to enable charging on A
+            pBootstrap->dutyA = RB_MIN_DUTY_FOR_BOOTSRAP_CHARGING;
+            // State Transition
+            pBootstrap->state= RBBS_A_CHARGING;
+            pBootstrap->delayCount = MCAF_BOARD_BOOTSTRAP_PHASE_DELAY;
+            break;
+            
+        case RBBS_A_CHARGING:
+            // Wait to let the the Phase-A bootstrap capacitor charge
+            // When the delay counter finishes, start charging B
+            if (pBootstrap->delayCount == 0)
+            {
+                pBootstrap->state= RBBS_B_SETUP;
+            }
+            break;
+        
+        case RBBS_B_SETUP:
+            // Set PWM A duty to enable charging on A
+            pBootstrap->dutyB = RB_MIN_DUTY_FOR_BOOTSRAP_CHARGING;
+            // State Transition
+            pBootstrap->state= RBBS_B_CHARGING;
+            pBootstrap->delayCount = MCAF_BOARD_BOOTSTRAP_PHASE_DELAY;
+            break;
+            
+        case RBBS_B_CHARGING:
+            // Wait to let the the Phase-A bootstrap capacitor charge
+            // When the delay counter finishes, start charging B
+            if (pBootstrap->delayCount == 0)
+            {
+                pBootstrap->state= RBBS_C_SETUP;
+            }
+            break;
+            
+        case RBBS_C_SETUP:
+            // Set PWM A duty to enable charging on A
+            pBootstrap->dutyC = RB_MIN_DUTY_FOR_BOOTSRAP_CHARGING;
+            // State Transition
+            pBootstrap->state= RBBS_C_CHARGING;
+            pBootstrap->delayCount = MCAF_BOARD_BOOTSTRAP_PHASE_DELAY;
+            break;
+            
+        case RBBS_C_CHARGING:
+            // Wait to let the the Phase-A bootstrap capacitor charge
+            // When the delay counter finishes, start charging B
+            if (pBootstrap->delayCount == 0)
+            {
+                pBootstrap->state = RBBS_DONE;
+            }
+            break;  
+            
+        case RBBS_DONE:
+            bootstrapDone = true;
+            break;
+    }
+    
+    // Final set duties
+    MCC_PWM_DutyCycleSet(MOTOR1_PHASE_A, pBootstrap->dutyA);
+    MCC_PWM_DutyCycleSet(MOTOR1_PHASE_B, pBootstrap->dutyB);
+    MCC_PWM_DutyCycleSet(MOTOR1_PHASE_C, pBootstrap->dutyC);
+    // Decrement delay counter
+    if (pBootstrap->delayCount > 0)
+    {
+        pBootstrap->delayCount--;
+    }
+    
+    return bootstrapDone;
+}
+

--- a/motor_controller/motorbench-test-project/motorbench-test-project/rb_library/rb_pwm.c
+++ b/motor_controller/motorbench-test-project/motorbench-test-project/rb_library/rb_pwm.c
@@ -56,7 +56,7 @@ bool RB_PWMCapBootstrapISRStep(RB_BOOTSTRAP *pBootstrap) {
             break;
         
         case RBBS_B_SETUP:
-            // Set PWM A duty to enable charging on A
+            // Set PWM B duty to enable charging on B
             pBootstrap->dutyB = RB_MIN_DUTY_FOR_BOOTSRAP_CHARGING;
             // State Transition
             pBootstrap->state= RBBS_B_CHARGING;
@@ -64,8 +64,8 @@ bool RB_PWMCapBootstrapISRStep(RB_BOOTSTRAP *pBootstrap) {
             break;
             
         case RBBS_B_CHARGING:
-            // Wait to let the the Phase-A bootstrap capacitor charge
-            // When the delay counter finishes, start charging B
+            // Wait to let the the Phase-B bootstrap capacitor charge
+            // When the delay counter finishes, start charging C
             if (pBootstrap->delayCount == 0)
             {
                 pBootstrap->state= RBBS_C_SETUP;
@@ -73,7 +73,7 @@ bool RB_PWMCapBootstrapISRStep(RB_BOOTSTRAP *pBootstrap) {
             break;
             
         case RBBS_C_SETUP:
-            // Set PWM A duty to enable charging on A
+            // Set PWM C duty to enable charging on C
             pBootstrap->dutyC = RB_MIN_DUTY_FOR_BOOTSRAP_CHARGING;
             // State Transition
             pBootstrap->state= RBBS_C_CHARGING;
@@ -81,8 +81,8 @@ bool RB_PWMCapBootstrapISRStep(RB_BOOTSTRAP *pBootstrap) {
             break;
             
         case RBBS_C_CHARGING:
-            // Wait to let the the Phase-A bootstrap capacitor charge
-            // When the delay counter finishes, start charging B
+            // Wait to let the the Phase-C bootstrap capacitor charge
+            // When the delay counter finishes, charging is done
             if (pBootstrap->delayCount == 0)
             {
                 pBootstrap->state = RBBS_DONE;

--- a/motor_controller/motorbench-test-project/motorbench-test-project/rb_library/rb_pwm.h
+++ b/motor_controller/motorbench-test-project/motorbench-test-project/rb_library/rb_pwm.h
@@ -8,12 +8,67 @@
 #ifndef RB_PWM_H
 #define	RB_PWM_H
 
+#include "board_service_types.h"
+
 #ifdef	__cplusplus
 extern "C" {
 #endif
 
+/**
+ * Defines
+ */    
+    
+// Simplified from the function minimumDutyCycleForBootstrapCharging()    
+// Dont know why this is the case    
+#define RB_MIN_DUTY_FOR_BOOTSRAP_CHARGING HAL_PARAM_MAX_DUTY_COUNTS   
+
+/**
+ * Typedefs
+ */
+    
+/**
+ * Bootstrap Capacitor Charging FSM states
+ */    
+typedef enum tagRB_BOOTSTRAP_STATE
+{
+    RBBS_IDLE,
+    RBBS_INIT_WAIT,
+    RBBS_A_SETUP,
+    RBBS_A_CHARGING,
+    RBBS_B_SETUP,
+    RBBS_B_CHARGING,
+    RBBS_C_SETUP,
+    RBBS_C_CHARGING,
+    RBBS_DONE
+} RB_BOOTSTRAP_STATE;
+
+typedef struct tagRB_BOOTSTRAP
+{
+    // defines what step of the bootstrap charging sequence we are in
+    RB_BOOTSTRAP_STATE state;
+    
+    // used to control delays in the bootstrap charging states
+    uint16_t delayCount;
+    
+    // used to store the 3 PWM duties during bootstrap charging
+    uint16_t dutyA;
+    uint16_t dutyB;
+    uint16_t dutyC;
+
+    
+} RB_BOOTSTRAP;
+
+/**
+ * Functions
+ */
 
 void RB_PWMInit(void);
+
+/**
+ * Function to perform capacitor bootstrap charging during motor starting
+ */
+bool RB_PWMCapBootstrapISRStep(RB_BOOTSTRAP *pBootstrap);
+
 
 #ifdef	__cplusplus
 }


### PR DESCRIPTION
Wrote a function for bootstrap capacitor charging that should be called in the main ISR. This function is based off of the motorbench project's bootstrap code, simplified for our application.

- The function should be called after the PWMs have been initialized and before any power is delivered to the motor. 
- When bootstrap is complete, the function returns true and the motor can begin running.