### PR TITLE
State machine, Board UI, and Frequency Modulation Sine PWM

### DIFF
--- a/motor_controller/motorbench-test-project/motorbench-test-project/main.c
+++ b/motor_controller/motorbench-test-project/motorbench-test-project/main.c
@@ -1,64 +1,21 @@
-/*
-� [2024] Microchip Technology Inc. and its subsidiaries.
+/* 
+ * File:   mc_hall.h
+ * Author: Chris Hyggen, Anish Sivakumar
+ *
+ */
 
-    Subject to your compliance with these terms, you may use Microchip 
-    software and any derivatives exclusively with Microchip products. 
-    You are responsible for complying with 3rd party license terms  
-    applicable to your use of 3rd party software (including open source  
-    software) that may accompany Microchip software. SOFTWARE IS ?AS IS.? 
-    NO WARRANTIES, WHETHER EXPRESS, IMPLIED OR STATUTORY, APPLY TO THIS 
-    SOFTWARE, INCLUDING ANY IMPLIED WARRANTIES OF NON-INFRINGEMENT,  
-    MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE. IN NO EVENT 
-    WILL MICROCHIP BE LIABLE FOR ANY INDIRECT, SPECIAL, PUNITIVE, 
-    INCIDENTAL OR CONSEQUENTIAL LOSS, DAMAGE, COST OR EXPENSE OF ANY 
-    KIND WHATSOEVER RELATED TO THE SOFTWARE, HOWEVER CAUSED, EVEN IF 
-    MICROCHIP HAS BEEN ADVISED OF THE POSSIBILITY OR THE DAMAGES ARE 
-    FORESEEABLE. TO THE FULLEST EXTENT ALLOWED BY LAW, MICROCHIP?S 
-    TOTAL LIABILITY ON ALL CLAIMS RELATED TO THE SOFTWARE WILL NOT 
-    EXCEED AMOUNT OF FEES, IF ANY, YOU PAID DIRECTLY TO MICROCHIP FOR 
-    THIS SOFTWARE.
-*/
-#include "mcc_generated_files/motorBench/mcaf_main.h"
-#include "mcc_generated_files/system/system.h"
-#include "mcc_generated_files/system/pins.h"
 
-#include <stdbool.h>
-#include "board_service.h"
-#include "hal.h"
-#include "system_state.h"
-#include "state_machine.h"
-#include "system_init.h"
-#include "foc.h"
-#include "diagnostics.h"
-#include "monitor.h"
-#include "stall_detect.h"
-#include "recover.h"
-#include "mcaf_watchdog.h"
-#include "mcaf_traps.h"
-#include "ui.h"
-#include "parameters/init_params.h"
-#include "mcaf_main.h"
-#include "test_harness.h"
-#include "fault_detect.h"
-#include "mcapi.h"
-#include "mcaf_sample_application.h"
-#include "xc.h"
-#include "current_measure.h"
+#include "motorBench/timing.h"
+#include "hal/hardware_access_functions.h"
+#include "motorbench/diagnostics.h"
 
 #include "X2CScope.h"
 #include "rb_library/rb_hall.h"
 #include "rb_library/rb_control.h"
 #include "rb_library/rb_pwm.h"
 
-/* Global Variables */
-
-/** Global instance of the main set of system state variables */
-MCAF_SYSTEM_DATA sysData;
-
-extern volatile MCAF_WATCHDOG_T watchdog;
-
-void MainInit(void);
-
+void RB_MainInit(void);
+void RB_SystemStart(void);
 
 
 /*
@@ -66,7 +23,7 @@ void MainInit(void);
 */
 int main(void)
 {
-    MainInit();
+    RB_MainInit();
 
     while(1)
     {
@@ -86,7 +43,7 @@ int main(void)
  * and Control Parameters
  * @return initialization success 
  */
-void MainInit (void)
+void RB_MainInit (void)
 {
     SYSTEM_Initialize();
     
@@ -103,16 +60,57 @@ void MainInit (void)
     HAL_ADC_SignalsInit();
     HAL_ADC_ResolutionInit();
     HAL_ADC_Enable();
-    MCAF_DiagnosticsInit(); // UART and X2C scope
-    MCAF_SystemStart(&sysData);
+    MCAF_DiagnosticsInit();
+    RB_SystemStart();
     HAL_TMR_TICK_Start();
-    
-    // Configure Hall ISRs and data
-    RB_HALL_Init();
     
     MCC_TMR_PROFILE_Start(); // start timer 1
     
     // move to initialization state before ISR starts
     RB_ISR_StateInit();
     
+}
+
+
+/**
+ * Starts system - copy of MCAF function
+ * @return 
+ */
+void RB_SystemStart(void)
+{
+    /* Output a short pulse as a testpoint signal,
+     * enable PWMs,
+     * enable ADC interrupt,
+     * begin main loop timing,
+     * and start board timer */
+
+    HAL_TestpointGp1_Activate();
+    MCAF_DelayNanoseconds(500);
+    HAL_TestpointGp1_Deactivate();
+    HAL_PWM_ADCTrigger1AEnable();
+
+    if (MCAF_SingleChannelEnabled())
+    {
+        HAL_PWM_ModeDualEdgeSingleUpdate();
+        HAL_PWM_SelectLocalPhase();
+        HAL_PWM_ADCTrigger2BEnable();
+        HAL_PWM_ADCTrigger2CEnable();
+    }
+    else
+    {
+        HAL_PWM_SelectMasterPhase();
+        
+        if (MCAF_IsDoubleUpdatePwmAllowed())
+        {
+            HAL_PWM_ModeDoubleUpdate();
+        }      
+        else
+        {
+            HAL_PWM_ModeSingleUpdate();
+        }
+    }
+    
+    HAL_PWM_ModuleEnable();
+    HAL_ADC_InterruptFlag_Clear();
+    HAL_ADC_Interrupt_Enable();
 }

--- a/motor_controller/motorbench-test-project/motorbench-test-project/nbproject/configurations.xml
+++ b/motor_controller/motorbench-test-project/motorbench-test-project/nbproject/configurations.xml
@@ -163,6 +163,7 @@
       <itemPath>rb_library/rb_measure.h</itemPath>
       <itemPath>rb_library/rb_isr.h</itemPath>
       <itemPath>rb_library/rb_pwm.h</itemPath>
+      <itemPath>rb_library/rb_board_ui.h</itemPath>
     </logicalFolder>
     <logicalFolder name="ExternalFiles"
                    displayName="Important Files"
@@ -282,6 +283,7 @@
       <itemPath>rb_library/rb_foc_params.h</itemPath>
       <itemPath>rb_library/rb_measure.c</itemPath>
       <itemPath>rb_library/rb_pwm.c</itemPath>
+      <itemPath>rb_library/rb_board_ui.c</itemPath>
     </logicalFolder>
   </logicalFolder>
   <projectmakefile>Makefile</projectmakefile>

--- a/motor_controller/motorbench-test-project/motorbench-test-project/rb_library/rb_board_ui.c
+++ b/motor_controller/motorbench-test-project/motorbench-test-project/rb_library/rb_board_ui.c
@@ -1,9 +1,11 @@
 #include "rb_board_ui.h"
 
 #include "system/pins.h"
+#include "adc/adc1.h"
 
 void RB_BoardUIInit(RB_BOARD_UI* boardUI) {
     boardUI->motorEnable.state = 0;
+    boardUI->potState = 0;
 }
 
 void RB_BoardUIButtonDebounce(RB_BUTTON* button, bool pressedHW) {
@@ -32,5 +34,7 @@ void RB_BoardUIService(RB_BOARD_UI* boardUI) {
     bool motorEnablePressedHW = !MCAF_BUTTON1_GetValue();
     RB_BoardUIButtonDebounce(&boardUI->motorEnable, motorEnablePressedHW);
 
+    // update potentiometer value
+    boardUI->potState = ADC1_ConversionResultGet(MCAF_ADC_POTENTIOMETER);
 
 }

--- a/motor_controller/motorbench-test-project/motorbench-test-project/rb_library/rb_board_ui.c
+++ b/motor_controller/motorbench-test-project/motorbench-test-project/rb_library/rb_board_ui.c
@@ -1,5 +1,6 @@
 #include "rb_board_ui.h"
 
+#include "hal/hardware_access_functions.h"
 #include "system/pins.h"
 #include "adc/adc1.h"
 
@@ -35,6 +36,6 @@ void RB_BoardUIService(RB_BOARD_UI* boardUI) {
     RB_BoardUIButtonDebounce(&boardUI->motorEnable, motorEnablePressedHW);
 
     // update potentiometer value
-    boardUI->potState = ADC1_ConversionResultGet(MCAF_ADC_POTENTIOMETER);
+    boardUI->potState = HAL_ADC_UnsignedFromSignedInput(ADC1_ConversionResultGet(MCAF_ADC_POTENTIOMETER));
 
 }

--- a/motor_controller/motorbench-test-project/motorbench-test-project/rb_library/rb_board_ui.c
+++ b/motor_controller/motorbench-test-project/motorbench-test-project/rb_library/rb_board_ui.c
@@ -1,0 +1,36 @@
+#include "rb_board_ui.h"
+
+#include "system/pins.h"
+
+void RB_BoardUIInit(RB_BOARD_UI* boardUI) {
+    boardUI->motorEnable.state = 0;
+}
+
+void RB_BoardUIButtonDebounce(RB_BUTTON* button, bool pressedHW) {
+    // If the stored button->pressed is not equal to the hardware value, we need
+    // to do debouncing
+    if (pressedHW != button->pressed) {
+        button->counter++;
+        // If the button has been pressed for an adequate amount of cycles, then
+        // change the stored button->pressed value
+        if (button->counter >= RB_BUTTON_DEBOUNCE_CYCLES) {
+            button->pressed = pressedHW;
+            button->counter = 0;
+            // If were detecting a down-press, then change the latching 
+            // button->state
+            if (button->pressed) {
+                button->state = !button->state;
+            }
+        }
+    } else {
+        button->counter = 0;
+    }
+}
+
+void RB_BoardUIService(RB_BOARD_UI* boardUI) {
+    // Service motor enable button
+    bool motorEnablePressedHW = !MCAF_BUTTON1_GetValue();
+    RB_BoardUIButtonDebounce(&boardUI->motorEnable, motorEnablePressedHW);
+
+
+}

--- a/motor_controller/motorbench-test-project/motorbench-test-project/rb_library/rb_board_ui.h
+++ b/motor_controller/motorbench-test-project/motorbench-test-project/rb_library/rb_board_ui.h
@@ -1,0 +1,34 @@
+/* 
+ * File:   rb_board_ui.h
+ * Author: Chris Hyggen
+ *
+ * Created on June 15, 2024, 12:55 PM
+ */
+
+#ifndef RB_BOARD_UI_H
+#define	RB_BOARD_UI_H
+
+#include "stdbool.h"
+#include "stdint.h"
+
+
+#define RB_BUTTON_DEBOUNCE_CYCLES 100
+
+typedef struct tagRB_BUTTON {
+    bool state; // latching
+    bool pressed; // non-latching 
+    uint16_t counter;
+} RB_BUTTON;
+
+typedef struct tagRB_BOARD_UI {
+    RB_BUTTON motorEnable;
+    uint16_t potState;
+} RB_BOARD_UI;
+
+void RB_BoardUIInit(RB_BOARD_UI* boardUI);
+
+void RB_BoardUIService(RB_BOARD_UI* boardUI);
+
+
+#endif	/* RB_BOARD_UI_H */
+

--- a/motor_controller/motorbench-test-project/motorbench-test-project/rb_library/rb_board_ui.h
+++ b/motor_controller/motorbench-test-project/motorbench-test-project/rb_library/rb_board_ui.h
@@ -22,7 +22,7 @@ typedef struct tagRB_BUTTON {
 
 typedef struct tagRB_BOARD_UI {
     RB_BUTTON motorEnable;
-    uint16_t potState;
+    int16_t potState;
 } RB_BOARD_UI;
 
 void RB_BoardUIInit(RB_BOARD_UI* boardUI);

--- a/motor_controller/motorbench-test-project/motorbench-test-project/rb_library/rb_board_ui.h
+++ b/motor_controller/motorbench-test-project/motorbench-test-project/rb_library/rb_board_ui.h
@@ -22,7 +22,7 @@ typedef struct tagRB_BUTTON {
 
 typedef struct tagRB_BOARD_UI {
     RB_BUTTON motorEnable;
-    int16_t potState;
+    uint16_t potState;
 } RB_BOARD_UI;
 
 void RB_BoardUIInit(RB_BOARD_UI* boardUI);

--- a/motor_controller/motorbench-test-project/motorbench-test-project/rb_library/rb_control.c
+++ b/motor_controller/motorbench-test-project/motorbench-test-project/rb_library/rb_control.c
@@ -49,7 +49,7 @@ bool RB_FocInit(RB_MOTOR_DATA *pPMSM)
     pPMSM->adcSelect = HADC_POTENTIOMETER;
     
     /* initialize ADC compensation parameters  */
-    RB_ADCCompensationInit(&pPMSM->currentCal); 
+    RB_ADCCompensationInit(&pPMSM->currentCalib); 
     
     //pPMSM->rVdc = MCAF_ComputeReciprocalDCLinkVoltage(INT16_MAX);
     

--- a/motor_controller/motorbench-test-project/motorbench-test-project/rb_library/rb_control.c
+++ b/motor_controller/motorbench-test-project/motorbench-test-project/rb_library/rb_control.c
@@ -49,7 +49,7 @@ bool RB_FocInit(RB_MOTOR_DATA *pPMSM)
     pPMSM->adcSelect = HADC_POTENTIOMETER;
     
     /* initialize ADC compensation parameters  */
-    RB_ADCCompensationInit(&pPMSM->currentCalibration); 
+    RB_ADCCompensationInit(&pPMSM->currentCal); 
     
     //pPMSM->rVdc = MCAF_ComputeReciprocalDCLinkVoltage(INT16_MAX);
     

--- a/motor_controller/motorbench-test-project/motorbench-test-project/rb_library/rb_control.c
+++ b/motor_controller/motorbench-test-project/motorbench-test-project/rb_library/rb_control.c
@@ -49,7 +49,7 @@ bool RB_FocInit(RB_MOTOR_DATA *pPMSM)
     pPMSM->adcSelect = HADC_POTENTIOMETER;
     
     /* initialize ADC compensation parameters  */
-    RB_ADCCompensationInit(&pPMSM->currentCalib); 
+    RB_ADCCalibrationInit(&pPMSM->currentCalib); 
     
     //pPMSM->rVdc = MCAF_ComputeReciprocalDCLinkVoltage(INT16_MAX);
     

--- a/motor_controller/motorbench-test-project/motorbench-test-project/rb_library/rb_control.h
+++ b/motor_controller/motorbench-test-project/motorbench-test-project/rb_library/rb_control.h
@@ -144,7 +144,7 @@ typedef struct tagPMSM
 //    MCAF_STOPPING_STATE stopping; /** Stopping timer state */
 
     /** current calibration parameters */
-    RB_MEASURE_CURRENT_T currentCalibration;
+    RB_MEASURE_CURRENT_T currentCal;
         
     /** initialization - current offsets */
     MCAF_MOTOR_INITIALIZATION initialization;  

--- a/motor_controller/motorbench-test-project/motorbench-test-project/rb_library/rb_control.h
+++ b/motor_controller/motorbench-test-project/motorbench-test-project/rb_library/rb_control.h
@@ -144,7 +144,7 @@ typedef struct tagPMSM
 //    MCAF_STOPPING_STATE stopping; /** Stopping timer state */
 
     /** current calibration parameters */
-    RB_MEASURE_CURRENT_T currentCal;
+    RB_MEASURE_CURRENT_T currentCalib;
         
     /** initialization - current offsets */
     MCAF_MOTOR_INITIALIZATION initialization;  

--- a/motor_controller/motorbench-test-project/motorbench-test-project/rb_library/rb_hall.c
+++ b/motor_controller/motorbench-test-project/motorbench-test-project/rb_library/rb_hall.c
@@ -8,11 +8,8 @@
 #include "rb_hall.h"
 #include "rb_isr.h"
 
-#include "../mcc_generated_files/motorBench/hal/hardware_access_functions.h"
-#include "../mcc_generated_files/motorBench/util.h"
-
-/** Global instance of the hall sensor variables */
-volatile RB_HALL_DATA hall;
+#include "hal/hardware_access_functions.h"
+#include "motorBench/util.h"
 
 
 /**
@@ -32,11 +29,11 @@ int16_t sectorToQ15Angle[8] =  // 3, 1, 5, 4, 6, 2 is the fwd order from hall si
 };
 
 
-void RB_HALL_Init(void){
+void RB_HALL_Init(RB_HALL_DATA *phall){
    
-    hall.periodKFilter = Q15(0.005); //Q15(0.01);
+    phall->periodKFilter = Q15(0.005); //Q15(0.01);
     //hall.period = 0xFFF0; //65520
-    RB_HALL_Reset();
+    RB_HALL_Reset(phall);
     
     // Configure ISRs
     IO_RE8_SetInterruptHandler(&RB_HALL_ISR);
@@ -44,45 +41,42 @@ void RB_HALL_Init(void){
     IO_RE10_SetInterruptHandler(&RB_HALL_ISR);
 }
 
-void RB_HALL_Reset(void)
+
+void RB_HALL_Reset(RB_HALL_DATA *phall)
 {
-    hall.timedOut = true;
-    hall.minSpeedReached = false;
-    hall.speed = 0;
-    hall.period = 0xffff;
-    hall.periodStateVar = 0xffffffff;
-    hall.periodFilter = 0xffff;
-    hall.phaseInc = 0;
-    
+    phall->timedOut = true;
+    phall->minSpeedReached = false;
+    phall->speed = 0;
+    phall->period = 0xffff;
+    phall->periodStateVar = 0xffffffff;
+    phall->periodFilter = 0xffff;
+    phall->phaseInc = 0;
 }
 
 
-void RB_HALL_StateChange(void)
+void RB_HALL_StateChange(RB_HALL_DATA *phall)
 {
     uint16_t tmr1_tmp = TMR1; // store timer1 count value
     TMR1 = 0; // reset timer 1 counter
     
     // Check if our TMR1 measurement was valid
-    if(hall.timedOut){
-        hall.timedOut = false;
+    if(phall->timedOut){
+        phall->timedOut = false;
     }else{
-        hall.minSpeedReached = true;
-        hall.period = tmr1_tmp;
+        phall->minSpeedReached = true;
+        phall->period = tmr1_tmp;
     }
 
-    hall.sector = RB_HALL_ValueRead();
+    phall->sector = RB_HALL_ValueRead();
     
     // Instead of making abrupt correction to the angle corresponding to hall sector, find the error and make gentle correction  
-    hall.thetaError = (sectorToQ15Angle[hall.sector] + OFFSET_CORRECTION) - hall.theta;
+    phall->thetaError = (sectorToQ15Angle[phall->sector] + OFFSET_CORRECTION) - phall->theta;
     
     // Find the correction to be done in every step
     // If "hallThetaError" is 2000, and "hallCorrectionFactor" = (2000/8) = 250
     // So the error of 2000 will be corrected in 8 steps, with each step being 250
-    hall.correctionFactor = hall.thetaError >> HALL_CORRECTION_DIVISOR;
-    hall.correctionCounter = HALL_CORRECTION_STEPS;
-    
-    // Run this in main ISR
-    //HallBasedEstimation();  
+    phall->correctionFactor = phall->thetaError >> HALL_CORRECTION_DIVISOR;
+    phall->correctionCounter = HALL_CORRECTION_STEPS;
 }
 
 uint16_t RB_HALL_ValueRead(void) 
@@ -97,27 +91,30 @@ uint16_t RB_HALL_ValueRead(void)
     return hallValue;
 }
 
-// called by FOC ADC interrupt
-int16_t RB_HALL_Estimate(void) 
+
+int16_t RB_HALL_Estimate(RB_HALL_DATA *phall) 
 {
-    if (hall.minSpeedReached){
+    // used for FOC calculations
+    int16_t thetaElectrical;
+    
+    if (phall->minSpeedReached){
 
         /* calculate filtered period = delta_period x filter_gain. 
             right shift result to remove extra 2^15 factor from fixed point multiplication*/
-        hall.periodStateVar += (((int32_t)hall.period - (int32_t)hall.periodFilter)*(int16_t)(hall.periodKFilter));
-        hall.periodFilter = (int16_t)(hall.periodStateVar>>15);
+        phall->periodStateVar += (((int32_t)phall->period - (int32_t)phall->periodFilter)*(int16_t)(phall->periodKFilter));
+        phall->periodFilter = (int16_t)(phall->periodStateVar>>15);
 
-        hall.phaseInc = __builtin_divud((uint32_t)PHASE_INC_MULTI,(uint16_t)(hall.periodFilter));
-        hall.speed = __builtin_divud((uint32_t)SPEED_MULTI,(uint16_t)(hall.periodFilter));
-        hall.theta = hall.theta + hall.phaseInc;
-
+        phall->phaseInc = __builtin_divud((uint32_t)PHASE_INC_MULTI,(uint16_t)(phall->periodFilter));
+        phall->speed = __builtin_divud((uint32_t)SPEED_MULTI,(uint16_t)(phall->periodFilter));
+        phall->theta = phall->theta + phall->phaseInc;
     }
     
-    int16_t thetaElectrical = hall.theta; //thetaElectrical used for FOC calculations
-        if(hall.correctionCounter > 0)
+    thetaElectrical = phall->theta; 
+        if(phall->correctionCounter > 0)
         {
-            hall.theta = hall.theta + hall.correctionFactor;
-            hall.correctionCounter--;
+            phall->theta = phall->theta + phall->correctionFactor;
+            phall->correctionCounter--;
         }
+    
     return thetaElectrical;
 }

--- a/motor_controller/motorbench-test-project/motorbench-test-project/rb_library/rb_hall.c
+++ b/motor_controller/motorbench-test-project/motorbench-test-project/rb_library/rb_hall.c
@@ -19,15 +19,15 @@ volatile RB_HALL_DATA hall;
  * LUT for the calculation of six sector to equivalent angle in Q15 format.
  *              Here the angle is varying from -32768 to 32767. 
  */
-int16_t sectorToQ15Angle[8] =  // 3, 2, 6, 4, 5, 1
+int16_t sectorToQ15Angle[8] =  // 3, 1, 5, 4, 6, 2 is the fwd order from hall signals 
 {
     0,
-    21845,      // sector-1 =
-    -21864,     // sector-2 = (-32768+10922)
+    -21845,      // sector-1 =
+    21864,     // sector-2 = (-32768+10922)
     -32768,     // sector-3
     0,          // sector-4
-    10922,      // sector-5
-    -10924,     //sector-6
+    -10922,      // sector-5
+    10924,     //sector-6
     0
 };
 

--- a/motor_controller/motorbench-test-project/motorbench-test-project/rb_library/rb_hall.h
+++ b/motor_controller/motorbench-test-project/motorbench-test-project/rb_library/rb_hall.h
@@ -70,19 +70,21 @@ typedef struct
 
 /**
  * initializes hall object
- * @param hall
+ * @param phall
  */    
-void RB_HALL_Init(void);
+void RB_HALL_Init(RB_HALL_DATA *phall);
 
 /**
  * Invalidates the hall data structure
+ * @param phall
  */
-void RB_HALL_Reset(void);
+void RB_HALL_Reset(RB_HALL_DATA *phall);
 
 /**
  * ISR for hall state change
+ * @param phall
  */
-void RB_HALL_StateChange(void);
+void RB_HALL_StateChange(RB_HALL_DATA *phall);
 
 
 /**
@@ -94,9 +96,9 @@ uint16_t RB_HALL_ValueRead(void);
 
 /**
  * Estimates electrical angle and rotor speed using hall bits
- *
+ * @param phall
  */
-int16_t RB_HALL_Estimate(void);
+int16_t RB_HALL_Estimate(RB_HALL_DATA *phall);
 
 
  

--- a/motor_controller/motorbench-test-project/motorbench-test-project/rb_library/rb_isr.h
+++ b/motor_controller/motorbench-test-project/motorbench-test-project/rb_library/rb_isr.h
@@ -37,6 +37,7 @@ RB_MOTOR_DATA PMSM;
 RB_FSM_STATE state;
 RB_BOOTSTRAP bootstrap;
 RB_BOARD_UI boardUI;
+uint16_t speedLevel = 9;
 
 /** system data, accessed directly */
 extern MCAF_SYSTEM_DATA systemData;
@@ -59,9 +60,6 @@ void __attribute__((interrupt, auto_psv)) HAL_ADC_ISR(void)
     
     // This function will update the button states and the POT value. 
     RB_BoardUIService(&boardUI);
-    // After calling it, these values are updated:
-    boardUI.motorEnable.state;
-    boardUI.potState;
             
     switch(state){
                 
@@ -111,7 +109,8 @@ void __attribute__((interrupt, auto_psv)) HAL_ADC_ISR(void)
             
             RB_ADCRead(&PMSM.currentCal, &PMSM.iabc, &PMSM.vDC);
             RB_HALL_Estimate();
-            RB_FixedFrequencySinePWM(9);
+            
+            RB_FixedFrequencySinePWM(boardUI.potState);
             
             if (!boardUI.motorEnable.state){
 

--- a/motor_controller/motorbench-test-project/motorbench-test-project/rb_library/rb_isr.h
+++ b/motor_controller/motorbench-test-project/motorbench-test-project/rb_library/rb_isr.h
@@ -20,6 +20,7 @@ extern "C" {
 #include "rb_control.h"
 #include "rb_hall.h"
 #include "rb_pwm.h"
+#include "rb_board_ui.h"
  
 typedef enum 
 {   
@@ -34,6 +35,7 @@ typedef enum
 RB_MOTOR_DATA PMSM;
 RB_FSM_STATE state;
 RB_BOOTSTRAP bootstrap;
+RB_BOARD_UI boardUI;
 
 bool bootstrapDone;
 
@@ -74,6 +76,8 @@ void __attribute__((interrupt, auto_psv)) HAL_ADC_ISR(void)
             RB_FocInit(&PMSM);
             
             RB_FixedFrequencySinePWMInit(); //for testing
+            RB_BoardUIInit(&boardUI);
+            
             
             state = RBFSM_STARTUP;
             break;
@@ -98,8 +102,19 @@ void __attribute__((interrupt, auto_psv)) HAL_ADC_ISR(void)
             
             // Sine Frequency = 1 / (X*(1/20000)*297)
             // RPM = 120*f/52
-            RB_FixedFrequencySinePWM(9);  // 9,10 tested
             
+            // This function will update the button states and the POT value. 
+            RB_BoardUIService(&boardUI);
+            // After calling it, the motor enable state can be obtained with:
+            boardUI.motorEnable.state;
+         
+            // Temporary solution to turn the motor off with button 1:
+            if (boardUI.motorEnable.state){
+                MCC_PWM_Disable();
+            }
+              
+            RB_FixedFrequencySinePWM(9);  // 9,10 tested
+              
             RB_HALL_Estimate();
           
             break;

--- a/motor_controller/motorbench-test-project/motorbench-test-project/rb_library/rb_isr.h
+++ b/motor_controller/motorbench-test-project/motorbench-test-project/rb_library/rb_isr.h
@@ -105,8 +105,11 @@ void __attribute__((interrupt, auto_psv)) HAL_ADC_ISR(void)
             
             // This function will update the button states and the POT value. 
             RB_BoardUIService(&boardUI);
-            // After calling it, the motor enable state can be obtained with:
+            // After calling it, these values are updated:
             boardUI.motorEnable.state;
+            boardUI.potState;
+            
+                  
          
             // Temporary solution to turn the motor off with button 1:
             if (boardUI.motorEnable.state){

--- a/motor_controller/motorbench-test-project/motorbench-test-project/rb_library/rb_isr.h
+++ b/motor_controller/motorbench-test-project/motorbench-test-project/rb_library/rb_isr.h
@@ -94,7 +94,7 @@ void __attribute__((interrupt, auto_psv)) HAL_ADC_ISR(void)
             } else if ((bootstrap.done) && (!PMSM.currentCalib.done))
             {
                // next, take current measurements to calculate offset over multiple steps
-               RB_MeasureCurrentOffsetStepISR(&PMSM.currentCalib); 
+               RB_ADCCalibrationStepISR(&PMSM.currentCalib); 
             
             } else if((bootstrap.done) && (PMSM.currentCalib.done) && (boardUI.motorEnable.state))
             {
@@ -113,7 +113,7 @@ void __attribute__((interrupt, auto_psv)) HAL_ADC_ISR(void)
             
         case RBFSM_RUNNING:         
             
-            RB_ADCRead(&PMSM.currentCalib, &PMSM.iabc, &PMSM.vDC);
+            RB_ADCReadStepISR(&PMSM.currentCalib, &PMSM.iabc, &PMSM.vDC);
             RB_HALL_Estimate(&hall);
             
             RB_FixedFrequencySinePWM(boardUI.potState);

--- a/motor_controller/motorbench-test-project/motorbench-test-project/rb_library/rb_measure.c
+++ b/motor_controller/motorbench-test-project/motorbench-test-project/rb_library/rb_measure.c
@@ -20,8 +20,8 @@ void RB_ADCCompensationInit(RB_MEASURE_CURRENT_T *pcal)
     pcal->sumIdc = 0;
     pcal->offsetIdc = 0;
     
-    pcal->calibrationCounter = 0;
-    pcal->calibrationComplete = false;
+    pcal->calCounter = 0;
+    pcal->done = false;
             
 
 }
@@ -35,7 +35,7 @@ void RB_ADCCompensationInit(RB_MEASURE_CURRENT_T *pcal)
 * @param Pointer to the data structure containing measured current.
 *
 */
-void RB_MeasureCurrentOffset(RB_MEASURE_CURRENT_T *pcal)
+void RB_MeasureCurrentOffsetStepISR(RB_MEASURE_CURRENT_T *pcal)
 {
     bool calibrationComplete = false;
     
@@ -47,18 +47,18 @@ void RB_MeasureCurrentOffset(RB_MEASURE_CURRENT_T *pcal)
     pcal->sumIa += pcal->rawIa;
     pcal->sumIb += pcal->rawIb;
     
-    pcal->calibrationCounter++;
+    pcal->calCounter++;
     
     // if we have summed enough samples, calculate offset average
-    if (pcal->calibrationCounter >= CURRENT_OFFSET_COUNT_MAX)
+    if (pcal->calCounter >= CURRENT_OFFSET_COUNT_MAX)
     {
         pcal->offsetIa = (int16_t)(pcal->sumIa >> CURRENT_OFFSET_COUNT_BITS);
         pcal->offsetIb = (int16_t)(pcal->sumIb >> CURRENT_OFFSET_COUNT_BITS);
 
-        pcal->calibrationCounter = 0;
+        pcal->calCounter = 0;
         pcal->sumIa = 0;
         pcal->sumIb = 0;
-        pcal->calibrationComplete = true;
+        pcal->done = true;
     }
    
 }
@@ -71,13 +71,8 @@ void RB_ADCRead(RB_MEASURE_CURRENT_T *pcal, MC_ABC_T *piabc, int16_t *pvDC)
     pcal->rawIb = MCC_ADC_ConversionResultGet(MCAF_ADC_PHASEB_CURRENT); 
     
     //2. apply current offset compensation
-    int16_t tempIa;
-    int16_t tempIb;
-    tempIa = RB_ADCProcess(pcal->rawIa, pcal->offsetIa);
-    tempIb = RB_ADCProcess(pcal->rawIb, pcal->offsetIb);
-    
-    piabc->a =  (__builtin_mulss(tempIa, pcal->qKaa)) >> 15;
-    piabc->b =  (__builtin_mulss(tempIb, pcal->qKbb)) >> 15;
+    piabc->a = RB_ADCProcess(pcal->rawIa, pcal->offsetIa, pcal->qKaa);
+    piabc->b = RB_ADCProcess(pcal->rawIb, pcal->offsetIb, pcal->qKbb);
     
     //3. read DC link voltage
     uint16_t unsignedVdc = HAL_ADC_UnsignedFromSignedInput(MCC_ADC_ConversionResultGet(MCAF_ADC_DCLINK_VOLTAGE));

--- a/motor_controller/motorbench-test-project/motorbench-test-project/rb_library/rb_measure.c
+++ b/motor_controller/motorbench-test-project/motorbench-test-project/rb_library/rb_measure.c
@@ -3,7 +3,7 @@
 #include "adc/adc1.h"
 
 
-void RB_ADCCompensationInit(RB_MEASURE_CURRENT_T *pcalib)
+void RB_ADCCalibrationInit(RB_MEASURE_CURRENT_T *pcalib)
 {
     /* Scaling constants: Determined by calibration or hardware design. */
     pcalib->qKaa = C_KAA;
@@ -26,7 +26,7 @@ void RB_ADCCompensationInit(RB_MEASURE_CURRENT_T *pcalib)
 }
 
 
-void RB_MeasureCurrentOffsetStepISR(RB_MEASURE_CURRENT_T *pcalib)
+void RB_ADCCalibrationStepISR(RB_MEASURE_CURRENT_T *pcalib)
 {
     
     // read phase A and B current into current compensation structure
@@ -53,7 +53,7 @@ void RB_MeasureCurrentOffsetStepISR(RB_MEASURE_CURRENT_T *pcalib)
 }
 
 
-void RB_ADCRead(RB_MEASURE_CURRENT_T *pcalib, MC_ABC_T *piabc, int16_t *pvDC)
+void RB_ADCReadStepISR(RB_MEASURE_CURRENT_T *pcalib, MC_ABC_T *piabc, int16_t *pvDC)
 {
     //1. read phase A and B current into current compensation structure
     pcalib->rawIa = MCC_ADC_ConversionResultGet(MCAF_ADC_PHASEA_CURRENT);

--- a/motor_controller/motorbench-test-project/motorbench-test-project/rb_library/rb_measure.c
+++ b/motor_controller/motorbench-test-project/motorbench-test-project/rb_library/rb_measure.c
@@ -21,31 +21,35 @@ void RB_ADCCompensationInit(RB_MEASURE_CURRENT_T *pcal)
     pcal->offsetIdc = 0;
     
     pcal->calibrationCounter = 0;
-    pcal->calibrationComplete = 0;
+    pcal->calibrationComplete = false;
             
 
 }
 
+
+
 /**
-* <B> Function: MCAPP_MeasureCurrentOffset(MCAPP_MEASURE_CURRENT_T *)  </B>
 *
 * @brief Function to compute current offset after measuring specified number of
-*        current samples and averaging them.
-*        .
+*        current samples and averaging them.      .
 * @param Pointer to the data structure containing measured current.
-* @return none.
-* @example
-* <CODE> MCAPP_MeasureCurrentOffset(&current); </CODE>
 *
 */
 void RB_MeasureCurrentOffset(RB_MEASURE_CURRENT_T *pcal)
 {
+    bool calibrationComplete = false;
     
+    // read phase A and B current into current compensation structure
+    pcal->rawIa = MCC_ADC_ConversionResultGet(MCAF_ADC_PHASEA_CURRENT);
+    pcal->rawIb = MCC_ADC_ConversionResultGet(MCAF_ADC_PHASEB_CURRENT);
+    
+    // sum current values
     pcal->sumIa += pcal->rawIa;
     pcal->sumIb += pcal->rawIb;
+    
     pcal->calibrationCounter++;
     
-    // if we have summed enough samples, calculate offset
+    // if we have summed enough samples, calculate offset average
     if (pcal->calibrationCounter >= CURRENT_OFFSET_COUNT_MAX)
     {
         pcal->offsetIa = (int16_t)(pcal->sumIa >> CURRENT_OFFSET_COUNT_BITS);
@@ -54,9 +58,11 @@ void RB_MeasureCurrentOffset(RB_MEASURE_CURRENT_T *pcal)
         pcal->calibrationCounter = 0;
         pcal->sumIa = 0;
         pcal->sumIb = 0;
-        pcal->calibrationComplete = 1;
+        pcal->calibrationComplete = true;
     }
+   
 }
+
 
 void RB_ADCRead(RB_MEASURE_CURRENT_T *pcal, MC_ABC_T *piabc, int16_t *pvDC)
 {
@@ -64,19 +70,14 @@ void RB_ADCRead(RB_MEASURE_CURRENT_T *pcal, MC_ABC_T *piabc, int16_t *pvDC)
     pcal->rawIa = MCC_ADC_ConversionResultGet(MCAF_ADC_PHASEA_CURRENT);
     pcal->rawIb = MCC_ADC_ConversionResultGet(MCAF_ADC_PHASEB_CURRENT); 
     
-    //2. apply current offset compensation if already complete
-    int16_t tempIa = pcal->rawIa;
-    int16_t tempIb = pcal->rawIb;
-    if(pcal->calibrationComplete == 1)
-    {
-        tempIa = RB_ADCProcess(pcal->rawIa, pcal->offsetIa);
-        tempIb = RB_ADCProcess(pcal->rawIb, pcal->offsetIb);
-    }
+    //2. apply current offset compensation
+    int16_t tempIa;
+    int16_t tempIb;
+    tempIa = RB_ADCProcess(pcal->rawIa, pcal->offsetIa);
+    tempIb = RB_ADCProcess(pcal->rawIb, pcal->offsetIb);
     
-    piabc->a =  (__builtin_mulss(tempIa, pcal->qKaa)
-                +__builtin_mulss(tempIb, pcal->qKab)) >> 15;
-    piabc->b =  (__builtin_mulss(tempIa, pcal->qKba)
-                +__builtin_mulss(tempIb, pcal->qKbb)) >> 15;
+    piabc->a =  (__builtin_mulss(tempIa, pcal->qKaa)) >> 15;
+    piabc->b =  (__builtin_mulss(tempIb, pcal->qKbb)) >> 15;
     
     //3. read DC link voltage
     uint16_t unsignedVdc = HAL_ADC_UnsignedFromSignedInput(MCC_ADC_ConversionResultGet(MCAF_ADC_DCLINK_VOLTAGE));

--- a/motor_controller/motorbench-test-project/motorbench-test-project/rb_library/rb_measure.c
+++ b/motor_controller/motorbench-test-project/motorbench-test-project/rb_library/rb_measure.c
@@ -1,6 +1,6 @@
 #include "rb_measure.h"
-#include "../motorBench/hal/hardware_access_functions.h"
-#include "../mcc_generated_files/adc/adc1.h"
+#include "hal/hardware_access_functions.h"
+#include "adc/adc1.h"
 
 
 void RB_ADCCompensationInit(RB_MEASURE_CURRENT_T *pcal)

--- a/motor_controller/motorbench-test-project/motorbench-test-project/rb_library/rb_measure.h
+++ b/motor_controller/motorbench-test-project/motorbench-test-project/rb_library/rb_measure.h
@@ -66,7 +66,7 @@ extern "C" {
     
     
 /**
- * Compensation for current measurements.
+ * Calibration/Compensation parameters for ADC current measurements.
  * 
  * These are applied as follows:
  * If Ia[0] and Ib[0] are the original ADC measurements, we calculate:
@@ -99,18 +99,43 @@ typedef struct
     int32_t                 sumIdc;        /* Accumulation of Idc to calculate offset*/
     int16_t                 offsetIdc;   /** DC link offset */
     
-    int16_t                 calCounter;  /** counted number of samples used to calc offset */
+    int16_t                 calibCounter;  /** counted number of samples used to calc offset */
     bool                    done; /** true when offset values have been calculated */
     
 } RB_MEASURE_CURRENT_T;
 
-void RB_ADCCompensationInit(RB_MEASURE_CURRENT_T *pcal);
+/**
+ * Initializes ADC scaling constants and offsets
+ * @param pcalib
+ */
+void RB_ADCCompensationInit(RB_MEASURE_CURRENT_T *pcalib);
 
-void RB_MeasureCurrentOffsetStepISR(RB_MEASURE_CURRENT_T *pcal);
 
-void RB_ADCRead(RB_MEASURE_CURRENT_T *pcal, MC_ABC_T *piabc, int16_t *pvDC);
+/**
+ * Measures average offset in ADC current reading at zero current flow
+ * over multiple ISR steps. Then, saves the offsets.
+ * @param pcalib
+ */
+void RB_MeasureCurrentOffsetStepISR(RB_MEASURE_CURRENT_T *pcalib);
 
-inline static int16_t RB_ADCProcess(int16_t measurement, int16_t offset, int16_t gain)
+
+/**
+ * Reads raw ADC values and applies compensation
+ * @param pcalib
+ * @param piabc
+ * @param pvDC
+ */
+void RB_ADCRead(RB_MEASURE_CURRENT_T *pcalib, MC_ABC_T *piabc, int16_t *pvDC);
+
+
+/**
+ * Apply current offset and scaling
+ * @param measurement
+ * @param offset
+ * @param gain
+ * @return 
+ */
+inline static int16_t RB_ADCCompensate(int16_t measurement, int16_t offset, int16_t gain)
 {
     int16_t temp;
     
@@ -124,7 +149,6 @@ inline static int16_t RB_ADCProcess(int16_t measurement, int16_t offset, int16_t
     
     return temp;
 }
-
 
 /**
  * 16 bit implementation of low pass filter

--- a/motor_controller/motorbench-test-project/motorbench-test-project/rb_library/rb_measure.h
+++ b/motor_controller/motorbench-test-project/motorbench-test-project/rb_library/rb_measure.h
@@ -100,11 +100,13 @@ typedef struct
     int16_t                 offsetIdc;   /** DC link offset */
     
     int16_t                 calibrationCounter;  /** counted number of samples used to calc offset */
-    int16_t                 calibrationComplete; /** 1 when offset values have been calculated */
+    bool                    calibrationComplete; /** true when offset values have been calculated */
     
 } RB_MEASURE_CURRENT_T;
 
 void RB_ADCCompensationInit(RB_MEASURE_CURRENT_T *pcal);
+
+void RB_MeasureCurrentOffset(RB_MEASURE_CURRENT_T *pcal);
 
 void RB_ADCRead(RB_MEASURE_CURRENT_T *pcal, MC_ABC_T *piabc, int16_t *pvDC);
 

--- a/motor_controller/motorbench-test-project/motorbench-test-project/rb_library/rb_measure.h
+++ b/motor_controller/motorbench-test-project/motorbench-test-project/rb_library/rb_measure.h
@@ -108,7 +108,7 @@ typedef struct
  * Initializes ADC scaling constants and offsets
  * @param pcalib
  */
-void RB_ADCCompensationInit(RB_MEASURE_CURRENT_T *pcalib);
+void RB_ADCCalibrationInit(RB_MEASURE_CURRENT_T *pcalib);
 
 
 /**
@@ -116,7 +116,7 @@ void RB_ADCCompensationInit(RB_MEASURE_CURRENT_T *pcalib);
  * over multiple ISR steps. Then, saves the offsets.
  * @param pcalib
  */
-void RB_MeasureCurrentOffsetStepISR(RB_MEASURE_CURRENT_T *pcalib);
+void RB_ADCCalibrationStepISR(RB_MEASURE_CURRENT_T *pcalib);
 
 
 /**
@@ -125,7 +125,7 @@ void RB_MeasureCurrentOffsetStepISR(RB_MEASURE_CURRENT_T *pcalib);
  * @param piabc
  * @param pvDC
  */
-void RB_ADCRead(RB_MEASURE_CURRENT_T *pcalib, MC_ABC_T *piabc, int16_t *pvDC);
+void RB_ADCReadStepISR(RB_MEASURE_CURRENT_T *pcalib, MC_ABC_T *piabc, int16_t *pvDC);
 
 
 /**

--- a/motor_controller/motorbench-test-project/motorbench-test-project/rb_library/rb_pwm.c
+++ b/motor_controller/motorbench-test-project/motorbench-test-project/rb_library/rb_pwm.c
@@ -89,6 +89,7 @@ void RB_PWMCapBootstrapInit(RB_BOOTSTRAP *pBootstrap) {
     pBootstrap->dutyA = 0;
     pBootstrap->dutyB = 0;
     pBootstrap->dutyC = 0;
+    pBootstrap->done = false;
 }
 
 

--- a/motor_controller/motorbench-test-project/motorbench-test-project/rb_library/rb_pwm.c
+++ b/motor_controller/motorbench-test-project/motorbench-test-project/rb_library/rb_pwm.c
@@ -93,9 +93,7 @@ void RB_PWMCapBootstrapInit(RB_BOOTSTRAP *pBootstrap) {
 }
 
 
-bool RB_PWMCapBootstrapISRStep(RB_BOOTSTRAP *pBootstrap) {
-
-    bool bootstrapDone = false;
+void RB_PWMCapBootstrapISRStep(RB_BOOTSTRAP *pBootstrap) {
 
     switch (pBootstrap->state) {
         case RBBS_IDLE:
@@ -174,7 +172,7 @@ bool RB_PWMCapBootstrapISRStep(RB_BOOTSTRAP *pBootstrap) {
             break;  
             
         case RBBS_DONE:
-            bootstrapDone = true;
+            pBootstrap->done = true;
             break;
     }
     
@@ -189,7 +187,6 @@ bool RB_PWMCapBootstrapISRStep(RB_BOOTSTRAP *pBootstrap) {
         pBootstrap->delayCount--;
     }
     
-    return bootstrapDone;
 }
 
 void RB_FixedFrequencySinePWMInit (void)

--- a/motor_controller/motorbench-test-project/motorbench-test-project/rb_library/rb_pwm.c
+++ b/motor_controller/motorbench-test-project/motorbench-test-project/rb_library/rb_pwm.c
@@ -199,7 +199,7 @@ void RB_FixedFrequencySinePWMInit (void)
 
 void RB_FixedFrequencySinePWM(uint16_t pot)
 {
-    uint16_t freqDivider;
+    uint16_t freqDivider = 9; // 9 is safe for starting
     
      
     if (pot < 33000)

--- a/motor_controller/motorbench-test-project/motorbench-test-project/rb_library/rb_pwm.c
+++ b/motor_controller/motorbench-test-project/motorbench-test-project/rb_library/rb_pwm.c
@@ -197,8 +197,34 @@ void RB_FixedFrequencySinePWMInit (void)
     sinePWM.phaseCIndex = 198;
 }
 
-void RB_FixedFrequencySinePWM(uint16_t freqDivider)
+void RB_FixedFrequencySinePWM(uint16_t pot)
 {
+    uint16_t freqDivider;
+    
+     
+    if (pot < 33000)
+    {
+        freqDivider = 9;
+    } else if ((pot >= 33000) && (pot < 40000))
+    {
+        freqDivider = 8;  
+    } else if ((pot >= 40000) && (pot < 45000))
+    {
+        freqDivider = 7;  
+    } else if ((pot >= 45000) && (pot < 50000))
+    {
+        freqDivider = 5;  
+    } else if ((pot >= 50000) && (pot < 55000))
+    {
+        freqDivider = 5;  
+    } else if ((pot >= 55000) && (pot < 60000))
+    {
+        freqDivider = 4;  
+    } else if (pot >= 60000)
+    {
+        freqDivider = 3;
+    } 
+    
     sinePWM.runningStateCounter++;
             
     // Sine Frequency = 1/ (X*(1/20000)*297), where phaseIndex++ if RunningStateCounter >= X

--- a/motor_controller/motorbench-test-project/motorbench-test-project/rb_library/rb_pwm.h
+++ b/motor_controller/motorbench-test-project/motorbench-test-project/rb_library/rb_pwm.h
@@ -86,7 +86,7 @@ void RB_PWMCapBootstrapInit(RB_BOOTSTRAP *pBootstrap);
 /**
  * Function to perform capacitor bootstrap charging during motor starting
  */
-bool RB_PWMCapBootstrapISRStep(RB_BOOTSTRAP *pBootstrap);
+void RB_PWMCapBootstrapISRStep(RB_BOOTSTRAP *pBootstrap);
 
 void RB_FixedFrequencySinePWMInit (void);
 

--- a/motor_controller/motorbench-test-project/motorbench-test-project/rb_library/rb_pwm.h
+++ b/motor_controller/motorbench-test-project/motorbench-test-project/rb_library/rb_pwm.h
@@ -55,6 +55,9 @@ typedef struct tagRB_BOOTSTRAP
     uint16_t dutyA;
     uint16_t dutyB;
     uint16_t dutyC;
+    
+    // true when bootstrap charging is complete
+    bool done;
 
     
 } RB_BOOTSTRAP;


### PR DESCRIPTION
- Updated FSM to have a stopping state
- Changed potState to uint16_t
- Added code to run the motor at speed up to 22Hz/50RPM depending on POT input 
- Program flows from INIT -> STARTUP -> RUNNING (if SW1 pressed) -> STOPPING (if SW1 pressed again) -> RUNNING (if SW1 pressed again)
- Validated switching between states in the lab 
- Validated higher speed motor operation with parallel DC Power Supply configuration and constant current/current limiting